### PR TITLE
Remove adding 'FALSE' to lists

### DIFF
--- a/cmake/Functions/CompileBinaryFunctions.cmake
+++ b/cmake/Functions/CompileBinaryFunctions.cmake
@@ -86,6 +86,8 @@ macro(internal_compile_binary_print_parse_result)
 	endif()
 	if (BINARY_DEBUG)
 		set(BINARY_DEBUG DEBUG)
+	else()
+		set(BINARY_DEBUG NO_DEBUG)
 	endif()
 endmacro(internal_compile_binary_print_parse_result)
 
@@ -195,6 +197,11 @@ macro(internal_compile_binary_add)
 
 	if (BINARY_TEST)
 		set(BINARY_TEST TEST)
+		if (BINARY_TEST_ARGUMENTS)
+			set(BINARY_TEST_ARGUMENTS ${BINARY_TEST} TEST_ARGUMENTS ${BINARY_TEST_ARGUMENTS})
+		else()
+			set(BINARY_TEST_ARGUMENTS ${BINARY_TEST})
+		endif()
 	endif()
 	internal_add_binary_target_properties(
 		PROPERTY_CONTAINER_NAME "${TARGET_CUSTOM_PROPERTIES}"
@@ -209,9 +216,7 @@ macro(internal_compile_binary_add)
 		INCLUDE_PATHS           "${BINARY_INCLUDE_PATHS}"
 		DEFINES                 "${BINARY_DEFINES}"
 
-		${BINARY_TEST}
-		TEST_ARGUMENTS          "${BINARY_TEST_ARGUMENTS}"
-
+		${BINARY_TEST_ARGUMENTS}
 		${BINARY_DEBUG}
 	)
 

--- a/cmake/Functions/CompileLibraryFunctions.cmake
+++ b/cmake/Functions/CompileLibraryFunctions.cmake
@@ -73,16 +73,16 @@ macro(internal_compile_library_print_parse_result)
 		print_debug_function_oneline("COMPILE_NOT_MAKE_POSITION_INDEPENDENT_OBJECTS = ")
 		print_debug_value_newline("${COMPILE_NOT_MAKE_POSITION_DEPENDENT_OBJECTS}")
 
-		print_debug_function_oneline("COMPILE_NO_RTTI =                               ")
+		print_debug_function_oneline("COMPILE_NO_RTTI                               = ")
 		print_debug_value_newline("${COMPILE_NO_RTTI}")
 
-		print_debug_function_oneline("COMPILE_RTTI =                                  ")
+		print_debug_function_oneline("COMPILE_RTTI                                  = ")
 		print_debug_value_newline("${COMPILE_RTTI}")
 
-		print_debug_function_oneline("COMPILE_NO_EXCEPTIONS =                         ")
+		print_debug_function_oneline("COMPILE_NO_EXCEPTIONS                         = ")
 		print_debug_value_newline("${COMPILE_NO_EXCEPTIONS}")
 
-		print_debug_function_oneline("COMPILE_EXCEPTIONS =                            ")
+		print_debug_function_oneline("COMPILE_EXCEPTIONS                            = ")
 		print_debug_value_newline("${COMPILE_EXCEPTIONS}")
 
 		print_debug_function_oneline("COMPILE_EXPORT_ALL                            = ")

--- a/cmake/Functions/CompileLibraryFunctions.cmake
+++ b/cmake/Functions/CompileLibraryFunctions.cmake
@@ -144,6 +144,8 @@ macro(internal_compile_library_print_parse_result)
 	endif()
 	if (COMPILE_DEBUG)
 		set(COMPILE_DEBUG DEBUG)
+	else()
+		set(COMPILE_DEBUG NO_DEBUG)
 	endif()
 endmacro(internal_compile_library_print_parse_result)
 
@@ -405,6 +407,8 @@ macro(internal_compile_shared_library)
 
 	if(COMPILE_EXPORT_ALL)
 		set(COMPILE_EXPORT_ALL EXPORT_ALL)
+	else()
+		set(COMPILE_EXPORT_ALL NO_EXPORT_ALL)
 	endif()
 
 	#set(DEBUG DEBUG)

--- a/cmake/Functions/HeaderLibraryFunctions.cmake
+++ b/cmake/Functions/HeaderLibraryFunctions.cmake
@@ -55,6 +55,8 @@ macro(internal_header_library_print_parse_result)
 	endif()
 	if (HEADER_DEBUG)
 		set(HEADER_DEBUG DEBUG)
+	else()
+		set(HEADER_DEBUG NO_DEBUG)
 	endif()
 endmacro(internal_header_library_print_parse_result)
 

--- a/cmake/Properties/TargetProperties.cmake
+++ b/cmake/Properties/TargetProperties.cmake
@@ -15,7 +15,7 @@
 function(internal_add_header_target_properties)
 	check_internal_use()
 
-	set(OPTIONS "DEBUG")
+	set(OPTIONS "DEBUG" "NO_DEBUG")
 	set(VALUES "PROPERTY_CONTAINER_NAME" "REAL_TARGET" "INSTALL_PATH")
 	set(LISTS "ADDING_FILES" "INCLUDE_PATHS" "DEPENDENCY_HEADERS" "LIBRARY_ALIASES")
 
@@ -86,7 +86,7 @@ endfunction(internal_add_header_target_properties)
 function(internal_add_object_target_properties)
 	check_internal_use()
 
-	set(OPTIONS "DEBUG" "POSITION_INDEPENDENT")
+	set(OPTIONS "DEBUG" "NO_DEBUG" "POSITION_INDEPENDENT")
 	set(VALUES "PROPERTY_CONTAINER_NAME" "REAL_TARGET")
 	set(LISTS "ADDING_FILES" "INCLUDE_PATHS" "DEFINES" "DEPENDENCY_HEADERS" "COMPILE_FLAGS"
 		"COMPILE_DIFINITIONS" "OBJECT_ALIASES")
@@ -164,7 +164,7 @@ endfunction(internal_add_object_target_properties)
 function(internal_add_static_target_properties)
 	check_internal_use()
 
-	set(OPTIONS "DEBUG")
+	set(OPTIONS "DEBUG" "NO_DEBUG")
 	set(VALUES "PROPERTY_CONTAINER_NAME" "REAL_TARGET" "OUTPUT_NAME" "INSTALL_PATH")
 	set(LISTS "ADDING_SOURCES" "ADDING_OBJECTS" "DEPENDENCY_HEADERS"
 		"DEPENDENCY_LIBRARIES" "COMPILE_FLAGS" "LIBRARY_ALIASES")
@@ -248,7 +248,7 @@ endfunction(internal_add_static_target_properties)
 function(internal_add_shared_target_properties)
 	check_internal_use()
 
-	set(OPTIONS "DEBUG" "EXPORT_ALL")
+	set(OPTIONS "DEBUG" "NO_DEBUG" "EXPORT_ALL" "NO_EXPORT_ALL")
 	set(VALUES "PROPERTY_CONTAINER_NAME" "REAL_TARGET" "OUTPUT_NAME" "INSTALL_PATH")
 	set(LISTS "ADDING_SOURCES" "ADDING_OBJECTS" "DEPENDENCY_HEADERS"
 		"DEPENDENCY_LIBRARIES" "COMPILE_FLAGS" "LINK_FLAGS" "LIBRARY_ALIASES")
@@ -345,7 +345,7 @@ endfunction(internal_add_shared_target_properties)
 function(internal_add_binary_target_properties)
 	enable_internal_use()
 
-	set(OPTIONS "DEBUG" "TEST")
+	set(OPTIONS "DEBUG" "NO_DEBUG" "TEST")
 	set(VALUES "PROPERTY_CONTAINER_NAME" "REAL_TARGET" "OUTPUT_NAME" "INSTALL_PATH")
 	set(LISTS "ADDING_FILES" "DEFINES" "INCLUDE_PATHS" "DEPENDENCY_HEADERS"
 		"DEPENDENCY_LIBRARIES" "COMPILE_FLAGS" "LINK_FLAGS" "TEST_ARGUMENTS")


### PR DESCRIPTION
On debug mode shows 'FALSE' on function arguments marked as list. So this commit fix this problem.
Tested with header, static, shared and object libraries.